### PR TITLE
Render variable name in warning text

### DIFF
--- a/Invoke-AzureADBulkUserCreation/Invoke-AzureADBulkUserCreation.ps1
+++ b/Invoke-AzureADBulkUserCreation/Invoke-AzureADBulkUserCreation.ps1
@@ -81,17 +81,17 @@ Foreach($Entry in $CSVData) {
     $Password = $Entry.PasswordProfile
     
 If(!$DisplayName) {
-    Write-Warning "$DisplayName is not provided. Continue to the next record"
+    Write-Warning '$DisplayName is not provided. Continue to the next record'
     Continue
 }
 
 If(!$MailNickName) {
-     Write-Warning "$MailNickName is not provided. Continue to the next record"
+     Write-Warning '$MailNickName is not provided. Continue to the next record'
     Continue
 }
 
 If(!$UserPrincipalName) {
-    Write-Warning "$UserPrincipalName is not provided. Continue to the next record"
+    Write-Warning '$UserPrincipalName is not provided. Continue to the next record'
     Continue
     }
 


### PR DESCRIPTION
If the required variables were missing, the script would try and display their value in the warning message. I've updated it to display the variable name.